### PR TITLE
fix android 4.1 bug

### DIFF
--- a/jquery.eraser.js
+++ b/jquery.eraser.js
@@ -65,6 +65,7 @@
               size = ( options && options.size )?options.size:40,
               completeRatio = ( options && options.completeRatio )?options.completeRatio:.7,
               completeFunction = ( options && options.completeFunction )?options.completeFunction:null,
+              zIndex = $this.css('z-index') == "auto"?1:$this.css('z-index'),
               parts = [],
               colParts = Math.floor( width / size ),
               numParts = colParts * Math.floor( height / size ),
@@ -118,7 +119,8 @@
               ratio: 0,
               complete: false,
               completeRatio: completeRatio,
-              completeFunction: completeFunction
+              completeFunction: completeFunction,
+              zIndex: zIndex
             };
             $canvas.data('eraser', data);
 
@@ -173,6 +175,7 @@
             data.touchY = ty;
             data.ctx.lineTo( data.touchX, data.touchY );
             data.ctx.stroke();
+            $this.css({"z-index":$this.css('z-index')==data.zIndex?parseInt(data.zIndex)+1:data.zIndex});
             event.preventDefault();
             break;
           }


### PR DESCRIPTION
For android 4.1, canvas didn't refresh after stroke(), so I toggle canvas's z-index to force refresh it.
