### PR TITLE
Make it compatible with jQuery 3+

### DIFF
--- a/jquery.eraser.js
+++ b/jquery.eraser.js
@@ -161,7 +161,7 @@
             handleImage();
           } else {
             //this.onload = handleImage;
-            $this.load(handleImage);
+            $this.on('load', handleImage);
           }
         }
       });


### PR DESCRIPTION
use 'on' event handler for image loading
jQuery 3 deprecates `.load()`